### PR TITLE
Feature/dns region

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,5 @@ Temporary Items
 
 # Linux trash folder which might appear on any partition or disk
 .Trash-*
+
+venv/

--- a/src/gogoutils/formats.py
+++ b/src/gogoutils/formats.py
@@ -24,6 +24,8 @@ DEFAULT_FORMAT = {
     'domain': 'example.com',
     'app': '{repo}{project}',
     'dns_elb': '{repo}.{project}.{env}.{domain}',
+    'dns_elb_region': '{repo}.{project}.{region}.{env}.{domain}',
+    'dns_noregion': '{repo}.{project}.{env}.{domain}',
     'dns_instance': '{repo}{project}-xx.{env}.{domain}',
     'iam_base': '{project}_{repo}',
     'iam_user': '{project}_{repo}',

--- a/src/gogoutils/formats.py
+++ b/src/gogoutils/formats.py
@@ -25,7 +25,7 @@ DEFAULT_FORMAT = {
     'app': '{repo}{project}',
     'dns_elb': '{repo}.{project}.{env}.{domain}',
     'dns_elb_region': '{repo}.{project}.{region}.{env}.{domain}',
-    'dns_noregion': '{repo}.{project}.{env}.{domain}',
+    'dns_global': '{repo}.{project}.{env}.{domain}',
     'dns_instance': '{repo}{project}-xx.{env}.{domain}',
     'iam_base': '{project}_{repo}',
     'iam_user': '{project}_{repo}',

--- a/src/gogoutils/generator.py
+++ b/src/gogoutils/generator.py
@@ -103,7 +103,7 @@ class Generator(object):
         dns = {
             'elb': self.dns_elb(),
             'elb_region': self.dns_elb_region(),
-            'global': self.dns_noregion(),
+            'global': self.dns_global(),
             'instance': self.dns_instance(),
         }
 

--- a/src/gogoutils/generator.py
+++ b/src/gogoutils/generator.py
@@ -25,12 +25,13 @@ class GeneratorError(Exception):
 class Generator(object):
     """Generates application details"""
 
-    def __init__(self, project, repo, env='dev', formats={}):
+    def __init__(self, project, repo, env='dev', region='us-east-1', formats={}):
 
         params = {
             'project': project,
             'repo': repo,
             'env': env,
+            'region': region
         }
 
         for param, value in params.items():
@@ -47,6 +48,7 @@ class Generator(object):
             'raw_project': params.get('project'),
             'raw_repo': params.get('repo'),
             'env': params.get('env').lower(),
+            'region': params.get('region').lower(),
         }
         self.data.update(self.format.get_formats())
 
@@ -81,6 +83,16 @@ class Generator(object):
         dns = self.format['dns_elb'].format(**self.data)
         return dns
 
+    def dns_elb_region(self):
+        """Generate dns domain"""
+        dns = self.format['dns_elb_region'].format(**self.data)
+        return dns
+
+    def dns_noregion(self):
+        """Generate dns domain"""
+        dns = self.format['dns_noregion'].format(**self.data)
+        return dns
+
     def dns_instance(self):
         """Generate dns instance"""
         instance = self.format['dns_instance'].format(**self.data)
@@ -90,6 +102,8 @@ class Generator(object):
         """Combined dns details"""
         dns = {
             'elb': self.dns_elb(),
+            'elb_region': self.dns_elb_region(),
+            'no_region': self.dns_noregion(),
             'instance': self.dns_instance(),
         }
 

--- a/src/gogoutils/generator.py
+++ b/src/gogoutils/generator.py
@@ -88,9 +88,9 @@ class Generator(object):
         dns = self.format['dns_elb_region'].format(**self.data)
         return dns
 
-    def dns_noregion(self):
-        """Generate dns domain with no region"""
-        dns = self.format['dns_noregion'].format(**self.data)
+    def dns_global(self):
+        """Generate dns global domain with no region"""
+        dns = self.format['dns_global'].format(**self.data)
         return dns
 
     def dns_instance(self):
@@ -103,7 +103,7 @@ class Generator(object):
         dns = {
             'elb': self.dns_elb(),
             'elb_region': self.dns_elb_region(),
-            'no_region': self.dns_noregion(),
+            'global': self.dns_noregion(),
             'instance': self.dns_instance(),
         }
 

--- a/src/gogoutils/generator.py
+++ b/src/gogoutils/generator.py
@@ -79,17 +79,17 @@ class Generator(object):
         return app
 
     def dns_elb(self):
-        """Generate dns domain"""
+        """Generate elb dns domain"""
         dns = self.format['dns_elb'].format(**self.data)
         return dns
 
     def dns_elb_region(self):
-        """Generate dns domain"""
+        """Generate dns domain with region"""
         dns = self.format['dns_elb_region'].format(**self.data)
         return dns
 
     def dns_noregion(self):
-        """Generate dns domain"""
+        """Generate dns domain with no region"""
         dns = self.format['dns_noregion'].format(**self.data)
         return dns
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -125,6 +125,7 @@ def test_generate_dns():
             PROJECTS[project]['project'],
             PROJECTS[project]['repo'],
             PROJECTS[project]['env'],
+            PROJECTS[project]['region'],
         )
 
         dns = '{0}.{1}.{2}.example.com'.format(

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -24,21 +24,25 @@ PROJECTS = {
         'project': 'gogoair',
         'repo': 'test',
         'env': 'dev',
+        'region': 'us-west-2',
     },
     'repo2': {
         'project': 'gogoair',
         'repo': 'test',
         'env': 'stage',
+        'region': 'us-east-1',
     },
     'repo3': {
         'project': 'project1',
         'repo': 'repo1',
         'env': 'env1',
+        'region': 'us-west-1',
     },
     'repo4': {
         'project': 'gogoair.test',
         'repo': 'unknown',
         'env': 'stage',
+        'region': 'us-west-2',
     },
 }
 
@@ -129,12 +133,20 @@ def test_generate_dns():
             PROJECTS[project]['env'],
         )
 
+        dns_withregion = '{0}.{1}.{2}.{3}.example.com'.format(
+            PROJECTS[project]['repo'],
+            PROJECTS[project]['project'],
+            PROJECTS[project]['region'],
+            PROJECTS[project]['env'],
+
+        )
         instance = '{0}{1}-xx.{2}.example.com'.format(
             PROJECTS[project]['repo'],
             PROJECTS[project]['project'],
             PROJECTS[project]['env'],
         )
         assert dns == g.dns()['elb']
+        assert dns_withregion == g.dns()['elb_region']
         assert instance == g.dns()['instance']
 
 


### PR DESCRIPTION
I needed to add the ability to handle regions in DNS. This is for multi-region deployments.

No existing functions or calls change, just added format for `dns_elb_region`, `dns_noregion`, and the ability to pass in region, defaulting to `us-east-1`. 