### PR TITLE
feat: Lambda Role Name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,7 @@ These are the services you can customize the formats along with their default fo
     git_repo,{raw_project}/{raw_repo},Apps git repo
     iam_base,{project}_{repo},IAM profile base
     iam_group,{project},IAM group name
+    iam_lambda_role,{project}_{repo}_lambda_role,Lambda IAM role name
     iam_policy,{project}_{repo}_policy,IAM policy name
     iam_profile,{project}_{repo}_profile,IAM profile name
     iam_role,{project}_{repo}_role,IAM role name

--- a/src/gogoutils/formats.py
+++ b/src/gogoutils/formats.py
@@ -32,6 +32,7 @@ DEFAULT_FORMAT = {
     'git_repo': '{raw_project}/{raw_repo}',
     'iam_base': '{project}_{repo}',
     'iam_group': '{project}',
+    'iam_lambda_role': '{project}_{repo}_lambda_role',
     'iam_policy': '{project}_{repo}_policy',
     'iam_profile': '{project}_{repo}_profile',
     'iam_role': '{project}_{repo}_role',

--- a/src/gogoutils/generator.py
+++ b/src/gogoutils/generator.py
@@ -118,6 +118,7 @@ class Generator(object):
 
         iam = {
             'group': self.format['iam_group'].format(**self.data),
+            'lambda_role': self.format['iam_lambda_role'].format(**self.data),
             'policy': self.format['iam_policy'].format(**self.data),
             'profile': self.format['iam_profile'].format(**self.data),
             'role': self.format['iam_role'].format(**self.data),

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -209,12 +209,14 @@ def test_generate_iam():
         )
 
         iam_group = PROJECTS[project]['project']
+        iam_lambda_role = '{0}_lambda_role'.format(iam_base)
         iam_policy = '{0}_policy'.format(iam_base)
         iam_profile = '{0}_profile'.format(iam_base)
         iam_role = '{0}_role'.format(iam_base)
         iam_user = iam_base
 
         assert iam_group == g.iam()['group']
+        assert iam_lambda_role == g.iam()['lambda_role']
         assert iam_policy == g.iam()['policy']
         assert iam_profile == g.iam()['profile']
         assert iam_role == g.iam()['role']


### PR DESCRIPTION
Provide a way to generate Lambda IAM Role names.

See also: https://github.com/gogoair/foremast/pull/112