### PR TITLE
test: Split linting as a separate step

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,14 @@
 [tox]
-envlist = py27,py34,py35
+envlist = py27,py34,py35,lint
 skip_missing_interpreters = True
 
 [testenv]
 deps = -rrequirements-dev.txt
+commands = py.test -s -v --cov-report term-missing --cov-report html --cov gogoutils
+recreate = True
+
+[testenv:lint]
+deps = -rrequirements-dev.txt
         prospector[with_everything]
 commands = prospector -0 -I __init__.py --strictness veryhigh --max-line-length 120
-           py.test -s -v --cov-report term-missing --cov-report html --cov gogoutils
-;recreate = True
+recreate = True


### PR DESCRIPTION
We should do linting step separately from the test cases, as it shouldn't necessarily block a PR.