### PR TITLE
Return ParserError when bad repo url detected

### DIFF
--- a/src/gogoutils/parser.py
+++ b/src/gogoutils/parser.py
@@ -46,6 +46,9 @@ class Parser(object):
             url = url.split(':')[1]
 
         # Ony capture last two list items
-        project, repo = url.split('/')[-2:]
+        try:
+            project, repo = url.split('/')[-2:]
+        except ValueError:
+            raise ParserError('"{}" is not a valid repository URL.'.format(self.url))
 
         return project, repo

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -69,6 +69,12 @@ def test_parser_case_url():
         assert repo == 'Test-config'
 
 
+def test_parser_invalid_url():
+    """Test url is valid when parsed"""
+    with pytest.raises(ParserError):
+        project, repo = Parser('https://github.com').parse_url()
+
+
 def test_empty_params():
     urls = [
         None,


### PR DESCRIPTION
We should try and gracefully handle when we cannot properly parse a url.

This at least gives us a better error when we hit those scenarios.